### PR TITLE
Handle Japanese past history selections

### DIFF
--- a/app/services/coaching_service.py
+++ b/app/services/coaching_service.py
@@ -64,11 +64,25 @@ def build_weekly_prompt(days: List[Dict[str, Any]], meals_by_day: Dict[str, List
         add("喫煙状況", "smoking_status")
         add("飲酒習慣", "alcohol_habit")
 
+
         if isinstance(profile.get("past_history"), list) and profile["past_history"]:
             mapping = {
-                "hypertension": "高血圧", "diabetes": "糖尿病", "cad": "心疾患",
-                "stroke": "脳卒中", "dyslipidemia": "脂質異常症",
-                "kidney": "腎疾患", "liver": "肝疾患", "asthma": "喘息", "other": "その他",
+                "hypertension": "高血圧",
+                "diabetes": "糖尿病",
+                "cad": "心疾患",
+                "stroke": "脳卒中（脳梗塞・脳出血）",
+                "asthma": "気管支喘息",
+                "copd": "慢性閉塞性肺疾患（COPD）",
+                "ulcer": "胃潰瘍・十二指腸潰瘍",
+                "hepatitis": "肝炎（B型・C型）",
+                "kidney": "慢性腎不全",
+                "cancer": "悪性腫瘍（がん）",
+                "osteoporosis": "骨粗鬆症",
+                "ra": "関節リウマチ",
+                "depression": "うつ病",
+                "epilepsy": "てんかん",
+                "drug_allergy": "薬剤アレルギー",
+                "other": "その他",
             }
             j = ", ".join(mapping.get(x, x) for x in profile["past_history"])
             prof_lines.append(f"- 既往歴: {j}")

--- a/static/index.html
+++ b/static/index.html
@@ -1391,8 +1391,27 @@
 
                     // 既往歴の設定
                     if (profile.past_history && Array.isArray(profile.past_history)) {
+                        const jp2eng = {
+                            "高血圧": "hypertension",
+                            "糖尿病": "diabetes",
+                            "心疾患": "cad",
+                            "脳卒中（脳梗塞・脳出血）": "stroke",
+                            "気管支喘息": "asthma",
+                            "慢性閉塞性肺疾患（COPD）": "copd",
+                            "胃潰瘍・十二指腸潰瘍": "ulcer",
+                            "肝炎（B型・C型）": "hepatitis",
+                            "慢性腎不全": "kidney",
+                            "悪性腫瘍（がん）": "cancer",
+                            "骨粗鬆症": "osteoporosis",
+                            "関節リウマチ": "ra",
+                            "うつ病": "depression",
+                            "てんかん": "epilepsy",
+                            "薬剤アレルギー": "drug_allergy",
+                            "その他": "other"
+                        };
                         profile.past_history.forEach(item => {
-                            const checkbox = document.getElementById(`past-${item}`);
+                            const value = jp2eng[item] || item;
+                            const checkbox = document.getElementById(`past-${value}`);
                             if (checkbox) {
                                 checkbox.checked = true;
                                 checkbox.closest('.multiselect-option').classList.add('selected');


### PR DESCRIPTION
## Summary
- Normalize stored Japanese past history values to internal codes when loading a profile
- Expand coaching service's past history translation map to cover all UI options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d7d3b4abc832080ce91f17b5ba2e4