### PR TITLE
refactor: rename ask_gpt5 to ask_gpt

### DIFF
--- a/app/external/openai_client.py
+++ b/app/external/openai_client.py
@@ -2,8 +2,8 @@ import httpx
 import base64
 from app.config import settings
 
-async def ask_gpt5(text: str) -> str:
-    """OpenAI Chat Completions API 呼び出し"""
+async def ask_gpt(text: str) -> str:
+    """Send a prompt to the OpenAI Chat Completions API and return the reply."""
     if not settings.OPENAI_API_KEY:
         return "（OPENAI_API_KEY が未設定です）"
     

--- a/app/routers/coaching.py
+++ b/app/routers/coaching.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from app.services.coaching_service import daily_coaching, weekly_coaching, monthly_coaching, build_daily_prompt
-from app.external.openai_client import ask_gpt5
+from app.external.openai_client import ask_gpt
 from app.external.line_client import push_line
 from app.config import settings
 import httpx
@@ -16,7 +16,7 @@ async def coach_now():
     
     day = await fitbit_today_core()
     prompt = build_daily_prompt(day)
-    msg = await ask_gpt5(prompt)
+    msg = await ask_gpt(prompt)
     res = push_line(f"📣 今日のコーチング\n{msg}")
     return {"sent": res, "model": settings.OPENAI_MODEL, "preview": msg}
 
@@ -29,7 +29,7 @@ async def coach_now_debug():
         
         day = await fitbit_today_core()
         prompt = build_daily_prompt(day)
-        out = await ask_gpt5(prompt)
+        out = await ask_gpt(prompt)
         return {"ok": True, "preview": out, "model": settings.OPENAI_MODEL}
     except httpx.HTTPStatusError as e:
         return JSONResponse({"ok": False, "status": e.response.status_code, "body": e.response.text[:1200]}, status_code=500)

--- a/app/routers/debug.py
+++ b/app/routers/debug.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from app.config import settings
-from app.external.openai_client import ask_gpt5
+from app.external.openai_client import ask_gpt
 from app.database.firestore import user_doc
 from datetime import datetime, timezone
 import httpx

--- a/app/services/coaching_service.py
+++ b/app/services/coaching_service.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
-from app.external.openai_client import ask_gpt5
+from app.external.openai_client import ask_gpt
 from app.external.line_client import push_line
 from app.services.meal_service import meals_last_n_days
 from app.database.firestore import get_latest_profile, user_doc
@@ -130,7 +130,7 @@ async def daily_coaching() -> Dict[str, Any]:
         
         # GPTでコーチング生成
         prompt = build_daily_prompt(day)
-        msg = await ask_gpt5(prompt)
+        msg = await ask_gpt(prompt)
         
         # LINE送信
         res = push_line(f"⏰ 毎日のコーチング\n{msg}")
@@ -169,7 +169,7 @@ async def weekly_coaching(dry: bool = False, show_prompt: bool = False) -> Dict[
         send_res = {"sent": False, "reason": "dry"}
         if not dry:
             try:
-                msg = await ask_gpt5(prompt)
+                msg = await ask_gpt(prompt)
             except Exception as e:
                 print(f"[ERROR] OpenAI failed: {e}")
                 msg = f"(OpenAI error) {e}"
@@ -252,7 +252,7 @@ async def monthly_coaching() -> Dict[str, Any]:
 3) 実行チェックリスト（5箇条、短く）
 """
 
-    monthly_text = await ask_gpt5(prompt)
+    monthly_text = await ask_gpt(prompt)
 
     # Firestore保存
     user_doc("demo").collection("coach_monthly").document(month_str).set({


### PR DESCRIPTION
## Summary
- rename `ask_gpt5` to `ask_gpt` and generalize docstring
- update all imports and callsites to use `ask_gpt`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d798498b08320bc10b5390cfa48db