### PR TITLE
fix: avoid closing past history dropdown when clicking selected text

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1198,7 +1198,7 @@
                 });
 
                 document.addEventListener('click', (e) => {
-                    if (!optionsContainer.contains(e.target) && e.target !== selectedDisplay) {
+                    if (!optionsContainer.contains(e.target) && !selectedDisplay.contains(e.target)) {
                         optionsContainer.style.display = 'none';
                     }
                 });


### PR DESCRIPTION
## Summary
- refine past history multiselect outside-click logic to ignore clicks inside the selected display

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d83ad07ac8320a268f7d03cf6a138