### PR TITLE
Initialize past history multiselect before loading profile

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1054,10 +1054,10 @@
             initializeApp() {
                 this.setupEventListeners();
                 this.setupPWA();
+                this.setupPastHistoryMultiselect();
                 this.loadProfile();
                 this.setupMealUpload();
                 this.initializeDashboard();
-                this.setupPastHistoryMultiselect();
                 this.restoreState();
                 
                 // デフォルトの日付設定


### PR DESCRIPTION
## Summary
- Ensure past history checkboxes are built before profile is loaded by reordering initialization sequence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d83b04d148320924bf05b73ea2198