### PR TITLE
fix: remove duplicate default date block

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1070,16 +1070,6 @@
                 document.getElementById('end-date').value = this.formatDate(today);
                 this.setDefaultMealDateTime();
             }
-                
-                // デフォルトの日付設定
-                const today = new Date();
-                const sevenDaysAgo = new Date(today);
-                sevenDaysAgo.setDate(today.getDate() - 6);
-
-                document.getElementById('start-date').value = this.formatDate(sevenDaysAgo);
-                document.getElementById('end-date').value = this.formatDate(today);
-                this.setDefaultMealDateTime();
-            }
 
             // イベントリスナー設定
             setupEventListeners() {


### PR DESCRIPTION
## Summary
- remove redundant default date initialization
- keep FitAIApp methods within class definition to enable navigation

## Testing
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dd528f9ec832098824f204c296ac9