### PR TITLE
Prefill current date/time on meal upload screen

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1311,6 +1311,11 @@
                 if (targetTab) {
                     targetTab.classList.add('active');
                 }
+
+                // 食事ページ表示時に現在日時を設定
+                if (pageId === 'meal') {
+                    this.setDefaultMealDateTime();
+                }
             }
 
             // 食事タブ切り替え


### PR DESCRIPTION
## Summary
- Auto-populate meal upload date/time fields with current values when opening the meal page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689de57848b083208b54831c5a30184a