### PR TITLE
Handle meal storage failures

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -131,7 +131,11 @@ async def ui_meal_image_no_store(
             "file_name": file.filename,
             "mime": mime,
         }
-        save_meal_to_stores(payload, "demo")
+        store_res = save_meal_to_stores(payload, "demo")
+        if not store_res.get("ok"):
+            store_res.setdefault("where", "storage")
+            store_res.setdefault("preview", text)
+            return JSONResponse(store_res, status_code=500)
     except Exception as e:
         return JSONResponse({"ok": False, "where": "storage", "error": repr(e),
                              "preview": text}, status_code=500)


### PR DESCRIPTION
## Summary
- add failure reporting to meal store helper
- return 500 from `/meal_image` when meal storage fails

## Testing
- `pytest -q`
- `python -m py_compile app/services/meal_service.py app/routers/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689dea2a91108320a2a88adb18e7ae2a