### PR TITLE
feat: add optional meal metadata fields

### DIFF
--- a/app/database/bigquery.py
+++ b/app/database/bigquery.py
@@ -41,6 +41,9 @@ def bq_insert_rows(table: str, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
                     "when_date": row_copy.get("when_date"),
                     "text": row_copy.get("text"),
                     "source": row_copy.get("source"),
+                    "meal_kind": row_copy.get("meal_kind"),
+                    "image_digest": row_copy.get("image_digest"),
+                    "notes": row_copy.get("notes"),
                     # whenは分単位で丸めて、同じ時間帯の重複を防ぐ
                     "when_rounded": row_copy.get("when", "")[:16] if row_copy.get("when") else ""  # YYYY-MM-DDTHH:MM
                 }

--- a/app/models/meal.py
+++ b/app/models/meal.py
@@ -5,6 +5,9 @@ class MealIn(BaseModel):
     when: str                 # "2025-08-10T12:30" など
     text: str
     kcal: Optional[float] = None
+    meal_kind: Optional[str] = None     # 朝食/昼食/夕食 など
+    image_digest: Optional[str] = None  # 画像内容のダイジェストなど
+    notes: Optional[str] = None         # 補足メモ
     
     # Pydantic v2 対応
     def dict(self):

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -67,6 +67,9 @@ def save_meal_to_stores(meal_data: Dict[str, Any], user_id: str = "demo") -> Dic
         "source": meal_data.get("source", "text"),
         "file_name": meal_data.get("file_name"),
         "mime": meal_data.get("mime"),
+        "meal_kind": meal_data.get("meal_kind"),
+        "image_digest": meal_data.get("image_digest"),
+        "notes": meal_data.get("notes"),
         "ingested_at": current_time,  # 統一されたタイムスタンプを使用
         "created_at": current_time,   # created_atも同じ値に統一
     }
@@ -111,6 +114,9 @@ def create_meal_dedup_key(meal_data: Dict[str, Any], user_id: str) -> str:
         "when_date": meal_data.get("when_date"),
         "text": meal_data.get("text"),
         "source": meal_data.get("source"),
+        "meal_kind": meal_data.get("meal_kind"),
+        "image_digest": meal_data.get("image_digest"),
+        "notes": meal_data.get("notes"),
         # 時刻は分単位で丸める（秒の違いによる重複を防ぐ）
         "when_rounded": meal_data.get("when", "")[:16] if meal_data.get("when") else ""
     }
@@ -135,11 +141,21 @@ def validate_meal_data(meal_data: Dict[str, Any]) -> Dict[str, Any]:
             float(meal_data["kcal"])
         except (ValueError, TypeError):
             errors.append("kcal must be a valid number")
-    
+
+    # 文字列型のチェック
+    str_fields = ["meal_kind", "image_digest", "notes"]
+    for field in str_fields:
+        if meal_data.get(field) is not None and not isinstance(meal_data.get(field), str):
+            errors.append(f"{field} must be a string")
+
     # テキストの長さチェック
     text = meal_data.get("text", "")
     if len(text) > 1000:  # 制限を設定
         errors.append("text is too long (max 1000 characters)")
+
+    notes = meal_data.get("notes") or ""
+    if len(notes) > 1000:
+        errors.append("notes is too long (max 1000 characters)")
     
     return {"valid": len(errors) == 0, "errors": errors}
 


### PR DESCRIPTION
## Summary
- add optional meal_kind, image_digest and notes to MealIn
- include new fields in meal deduplication and BigQuery row IDs
- validate and persist the new meal attributes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e002210248320b232fe59ecec50da