### PR TITLE
refactor: clean up unused imports

### DIFF
--- a/app/database/bigquery.py
+++ b/app/database/bigquery.py
@@ -2,7 +2,7 @@
 
 from google.cloud import bigquery
 from datetime import datetime, timezone
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from app.config import settings
 import hashlib
 import json

--- a/app/external/fitbit_client.py
+++ b/app/external/fitbit_client.py
@@ -1,7 +1,7 @@
 import asyncio
 import base64
 import httpx
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from app.config import settings
 from app.database.firestore import fitbit_token_doc
 

--- a/app/models/fitbit.py
+++ b/app/models/fitbit.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from typing import Optional
 
 class FitbitDayData(BaseModel):
     date: str

--- a/app/models/healthplanet.py
+++ b/app/models/healthplanet.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List, Dict, Any
+from typing import Optional, List
 
 class HealthPlanetData(BaseModel):
     measured_at: str

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,2 +1,5 @@
 # API routers
+# Re-export routers for external usage
 from . import dashboard
+
+__all__ = ["dashboard"]

--- a/app/routers/coaching.py
+++ b/app/routers/coaching.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from app.services.coaching_service import daily_coaching, weekly_coaching, monthly_coaching, build_daily_prompt
+from app.services.coaching_service import weekly_coaching, monthly_coaching, build_daily_prompt
 from app.external.openai_client import ask_gpt
 from app.external.line_client import push_line
 from app.config import settings

--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Any, Optional
+from datetime import datetime, timedelta
+from typing import Dict, List, Any
 from google.cloud import bigquery
 from app.database.bigquery import bq_client
 from app.config import settings
@@ -205,7 +205,7 @@ async def get_weight_dashboard_data(
             }
         }
         
-    except Exception as e:
+    except Exception:
         # Health Planetデータがない場合は空のデータを返す
         return {
             "ok": True,

--- a/app/routers/debug.py
+++ b/app/routers/debug.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from app.config import settings
-from app.external.openai_client import ask_gpt
 from app.database.firestore import user_doc
 from datetime import datetime, timezone
 import httpx

--- a/app/routers/fitbit.py
+++ b/app/routers/fitbit.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from fastapi.responses import RedirectResponse, JSONResponse
-from app.external.fitbit_client import get_redirect_uri, fitbit_exchange_code, get_fitbit_access_token
+from app.external.fitbit_client import get_redirect_uri, fitbit_exchange_code
 from app.services.fitbit_service import fitbit_today_core, fitbit_last_n_days, save_fitbit_daily_firestore, save_last7_fitbit_to_stores
 from app.database.firestore import fitbit_token_doc
 from app.external.line_client import push_line

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -1,12 +1,11 @@
 # app/routers/ui.py
 
-from fastapi import APIRouter, HTTPException, Header, File, UploadFile, Form, Query
+from fastapi import APIRouter, Header, File, UploadFile, Form, Query
 from fastapi.responses import JSONResponse
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from app.models.meal import MealIn
 from app.services.meal_service import save_meal_to_stores, to_when_date_str, validate_meal_data
 from app.external.openai_client import vision_extract_meal_bytes
-from app.database.firestore import user_doc
 from app.config import settings
 from app.utils.auth_utils import require_token
 import hashlib

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -2,8 +2,8 @@
 
 import hashlib
 import json
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Any
+from datetime import datetime, timezone
+from typing import Dict, Any
 from app.database.firestore import user_doc
 from app.database.bigquery import bq_client
 from app.config import settings

--- a/app/services/weight_service.py
+++ b/app/services/weight_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 from app.external.healthplanet_client import fetch_innerscan_data, get_access_token, jst_now, format_datetime
 from app.database.firestore import user_doc


### PR DESCRIPTION
## Summary
- remove unused imports across routers, services, and external modules
- explicitly re-export dashboard router

## Testing
- `ruff check .`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_689e0bed404c8320b6feb95a7f855158