### PR TITLE
refactor: centralize to_when_date_str

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -4,10 +4,11 @@ from fastapi import APIRouter, Header, File, UploadFile, Form, Query
 from fastapi.responses import JSONResponse
 from datetime import datetime, timezone
 from app.models.meal import MealIn
-from app.services.meal_service import save_meal_to_stores, to_when_date_str, validate_meal_data
+from app.services.meal_service import save_meal_to_stores, validate_meal_data
 from app.external.openai_client import vision_extract_meal_bytes
 from app.config import settings
 from app.utils.auth_utils import require_token
+from app.utils.date_utils import to_when_date_str
 import hashlib
 import uuid
 import logging

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -5,12 +5,7 @@ from typing import Dict, List, Any
 from app.database.firestore import user_doc
 from app.database.bigquery import bq_client, bq_insert_rows
 from app.config import settings
-
-def to_when_date_str(iso_str: str | None) -> str:
-    """ISO8601文字列の先頭10桁(YYYY-MM-DD)を日付キーとして返す"""
-    if not iso_str:
-        return datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d")
-    return iso_str[:10]
+from app.utils.date_utils import to_when_date_str
 
 async def meals_last_n_days(n: int = 7, user_id: str = "demo") -> Dict[str, List[Dict[str, Any]]]:
     """


### PR DESCRIPTION
## Summary
- reuse to_when_date_str from date_utils instead of duplicating
- update UI router to import to_when_date_str from date_utils

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e13d9b0608320ae33595e971b4603