### PR TITLE
Use dedup key for meal save responses

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -115,17 +115,18 @@ async def ui_meal_image(
                 status_code=500,
             )
 
+        skipped = save_res.get("firestore", {}).get("skipped")
         resp = {
             "ok": True,
-            "row_id": save_res["row_id"],
+            "dedup_key": save_res["dedup_key"],
             "request_id": request_id,
-            "inserted": save_res.get("inserted", False),
+            "inserted": not skipped,
             "preview": text,
         }
-        if not save_res.get("inserted"):
+        if skipped:
             resp["message"] = "既に登録済みのデータです（重複をスキップしました）"
 
-        logger.info(f"[MEAL_IMAGE] success row_id={save_res['row_id']} request_id={request_id}")
+        logger.info(f"[MEAL_IMAGE] success dedup_key={save_res['dedup_key']} request_id={request_id}")
         return resp
 
     except Exception as e:
@@ -160,16 +161,17 @@ def ui_meal(
 
     try:
         save_res = save_meal_to_stores(payload, user_id)
+        skipped = save_res.get("firestore", {}).get("skipped")
         resp = {
             "ok": save_res["ok"],
-            "row_id": save_res["row_id"],
+            "dedup_key": save_res["dedup_key"],
             "request_id": request_id,
-            "inserted": save_res.get("inserted", False),
+            "inserted": not skipped,
         }
-        if not save_res.get("inserted"):
+        if skipped:
             resp["message"] = "既に登録済みのデータです（重複をスキップしました）"
 
-        logger.info(f"[MEAL_TEXT] done row_id={save_res['row_id']} request_id={request_id}")
+        logger.info(f"[MEAL_TEXT] done dedup_key={save_res['dedup_key']} request_id={request_id}")
         return resp
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Replace `row_id` usage with new `dedup_key` from `save_meal_to_stores`
- Determine insertion status via `firestore.skipped`

## Testing
- `python -m pytest`
- Manual Test: `fastapi.testclient` POST `/ui/meal` (inserted)`
- Manual Test: `fastapi.testclient` POST `/ui/meal` (duplicate)`

------
https://chatgpt.com/codex/tasks/task_e_689e13d602bc8320a6c703e97247b131