### PR TITLE
Fix empty meal image uploads

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -42,6 +42,12 @@ async def ui_meal_image(
     data: bytes = await file.read()
     mime = file.content_type or "image/png"
 
+    if len(data) == 0:
+        return JSONResponse(
+            {"ok": False, "error": "Empty file", "request_id": request_id},
+            status_code=400,
+        )
+
     if dry:
         return {
             "ok": True,
@@ -188,6 +194,9 @@ async def ui_meal_image_preview(
     require_token(x_api_token)
     data: bytes = await file.read()
     mime = file.content_type or "image/png"
+
+    if len(data) == 0:
+        return JSONResponse({"ok": False, "error": "Empty file"}, status_code=400)
 
     if not settings.OPENAI_API_KEY:
         return JSONResponse({"ok": False, "error": "OPENAI_API_KEY not set"}, status_code=500)

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:8080")
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_meal_image_empty_file_returns_400():
+    response = client.post(
+        "/ui/meal_image?dry=true",
+        files={"file": ("empty.png", b"", "image/png")},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Empty file"
+
+
+def test_meal_image_preview_empty_file_returns_400():
+    response = client.post(
+        "/ui/meal_image/preview",
+        files={"file": ("empty.png", b"", "image/png")},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Empty file"
+


### PR DESCRIPTION
## 概要
- UI回帰の監査と不具合修正

## 主な修正点
- 空の画像アップロードで予期せぬエラーが発生する不具合を修正
- プレビューAPIでも同様のチェックを追加

## 再現手順 / 確認手順
1. `/ui/meal_image?dry=true` に空ファイルを送信
2. 期待: 400 エラー / 実際: 500 エラー
3. 修正後: 400 エラーと `Empty file` メッセージ

## リスクと影響範囲
- 影響するコンポーネント：`ui_meal_image`, `ui_meal_image_preview`

## スクリーンショット
- N/A

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e179251488320945111550f226804