### PR TITLE
fix: avoid crashes without Google credentials

### DIFF
--- a/app/database/bigquery.py
+++ b/app/database/bigquery.py
@@ -1,13 +1,19 @@
 # app/database/bigquery.py - 修正版
 
 from google.cloud import bigquery
+from google.auth.exceptions import DefaultCredentialsError
 from datetime import datetime, timezone
 from typing import List, Dict, Any
 from app.config import settings
 import hashlib
 import json
 
-bq_client = bigquery.Client(project=settings.BQ_PROJECT_ID) if settings.BQ_PROJECT_ID else None
+# BigQueryクライアントは環境に認証情報がない場合がある。
+# その際はNoneとして扱い、アプリケーション全体が起動できるようにする。
+try:
+    bq_client = bigquery.Client(project=settings.BQ_PROJECT_ID) if settings.BQ_PROJECT_ID else None
+except DefaultCredentialsError:
+    bq_client = None
 
 def bq_insert_rows(table: str, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     """BigQueryにデータを挿入。

--- a/app/database/firestore.py
+++ b/app/database/firestore.py
@@ -1,21 +1,33 @@
 from google.cloud import firestore
+from google.auth.exceptions import DefaultCredentialsError
 from typing import Dict, Any
 
-db = firestore.Client()
+try:
+    db = firestore.Client()
+except DefaultCredentialsError:
+    db = None
 
 def user_doc(user_id: str = "demo"):
     """ユーザードキュメントの参照を返す"""
+    if not db:
+        raise RuntimeError("Firestore client is not configured")
     return db.collection("users").document(user_id)
 
 def get_latest_profile(user_id: str = "demo") -> Dict[str, Any]:
     """最新プロフィールを取得"""
+    if not db:
+        return {}
     snap = user_doc(user_id).collection("profile").document("latest").get()
     return snap.to_dict() if snap.exists else {}
 
 def fitbit_token_doc(user_id: str = "demo"):
     """Fitbitトークンドキュメントの参照を返す"""
+    if not db:
+        raise RuntimeError("Firestore client is not configured")
     return user_doc(user_id).collection("private").document("fitbit_oauth")
 
 def healthplanet_token_doc(user_id: str = "demo"):
     """Health Planetトークンドキュメントの参照を返す"""
+    if not db:
+        raise RuntimeError("Firestore client is not configured")
     return user_doc(user_id).collection("private").document("healthplanet_oauth")


### PR DESCRIPTION
## 概要
- UI回帰の監査と不具合修正

## 主な修正点
- BigQuery/Firestoreクライアント初期化時に認証情報が無い場合はスキップするよう変更

## 再現手順 / 確認手順
1. Google Cloudの認証情報を設定せずにアプリを起動
2. 期待: サーバーが起動する
3. 実際: 以前は`DefaultCredentialsError`で起動に失敗
4. 修正後: 正常に起動する

## リスクと影響範囲
- 影響するコンポーネント：BigQuery連携, Firestore連携

## スクリーンショット
- N/A

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e82c46c3883209927fb3c9f69f7dd