### PR TITLE
Prevent duplicate meal inserts from image uploads

### DIFF
--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -3,7 +3,8 @@
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Any
 from app.database.firestore import user_doc
-from app.database.bigquery import bq_client, bq_insert_rows
+from app.database.bigquery import bq_client
+from google.cloud import bigquery
 from app.config import settings
 from app.utils.date_utils import to_when_date_str
 
@@ -90,7 +91,6 @@ def save_meal_to_stores(meal_data: Dict[str, Any], user_id: str = "demo") -> Dic
         "notes": meal_data.get("notes"),
         "ingested_at": current_time,  # 統一されたタイムスタンプを使用
         "created_at": current_time,   # created_atも同じ値に統一
-        "dedup_key": dedup_key,
     }
 
     try:


### PR DESCRIPTION
## Summary
- remove BigQuery query for nonexistent `dedup_key` column
- rely on `insert_rows_json` with row IDs for deduplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8f743be8832084496571220e4543