### PR TITLE
fix: avoid double meal upload

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1530,26 +1530,13 @@
                     formData.append('file', this.selectedFile);
                     formData.append('when', whenISO);
 
-                    // 最初にトークンありで試行
-                    let headers = {};
-                    if (this.apiToken) {
-                        headers['x-api-token'] = this.apiToken;
-                    }
-
-                    let response = await fetch(`${this.apiBaseUrl}/ui/meal_image`, {
+                    // トークンがあればヘッダーに付与して1回だけ送信
+                    const headers = this.apiToken ? { 'x-api-token': this.apiToken } : {};
+                    const response = await fetch(`${this.apiBaseUrl}/ui/meal_image`, {
                         method: 'POST',
                         headers: headers,
                         body: formData
                     });
-
-                    // 401エラーの場合、トークンなしで再試行
-                    if (response.status === 401) {
-                        console.log('401 error detected, retrying without token...');
-                        response = await fetch(`${this.apiBaseUrl}/ui/meal_image`, {
-                            method: 'POST',
-                            body: formData
-                        });
-                    }
 
                     const responseClone = response.clone();
 


### PR DESCRIPTION
## Summary
- ensure meal upload button sends only one request

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb255a91c8320ac17459ef04705e9