### PR TITLE
Delay dashboard chart initialization

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1059,7 +1059,6 @@
                 this.setupPastHistoryMultiselect();
                 this.loadProfile();
                 this.setupMealUpload();
-                this.initializeDashboard();
                 this.restoreState();
                 
                 // デフォルトの日付設定
@@ -1285,7 +1284,13 @@
                 
                 // ページ固有の処理
                 if (pageId === 'dashboard') {
-                    setTimeout(() => this.updateDashboard(), 100);
+                    if (Object.keys(this.charts).length === 0) {
+                        this.initializeDashboard();
+                    }
+                    setTimeout(() => {
+                        Object.values(this.charts).forEach(chart => chart.resize());
+                        this.updateDashboard();
+                    }, 100);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Avoid generating dashboard charts on app init
- Initialize charts when navigating to dashboard and resize canvases before updating data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eefe5028083209a6d5bd2e0ed8250