### PR TITLE
Serialize HealthPlanet raw item for BigQuery

### DIFF
--- a/app/services/healthplanet_service.py
+++ b/app/services/healthplanet_service.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 from typing import List, Dict, Any
+import json
+
 from app.external.healthplanet_client import fetch_innerscan_data, jst_now, format_datetime
 from app.database.bigquery import bq_client
 from app.config import settings
@@ -62,7 +64,7 @@ def to_bigquery_rows(user_id: str, raw_data: Dict[str, Any]) -> List[Dict[str, A
             "value": float_value,
             "unit": item.get("unit") or None,
             "ingested": now,
-            "raw": item,
+            "raw": json.dumps(item, ensure_ascii=False),
             "weight": float_value if tag == "6021" else None,
             "fat_percentage": float_value if tag == "6022" else None,
         })


### PR DESCRIPTION
## Summary
- Serialize `raw` HealthPlanet entries to JSON before inserting into BigQuery

## Testing
- `pytest -q`
- `curl -s -X POST http://localhost:8000/healthplanet/innerscan/last7/save_bq -H 'Content-Type: application/json'` *(fails: Firestore client is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e244d9108320bb3e2f4e2de62dd5