### PR TITLE
Avoid duplicate HealthPlanet entries on BigQuery insertion

### DIFF
--- a/tests/test_healthplanet_service.py
+++ b/tests/test_healthplanet_service.py
@@ -8,7 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.services.healthplanet_service import to_bigquery_rows
+from types import SimpleNamespace
+
+from app.services.healthplanet_service import to_bigquery_rows, save_to_bigquery
 
 
 def test_to_bigquery_rows_combines_weight_and_fat_percentage():
@@ -40,3 +42,36 @@ def test_to_bigquery_rows_combines_weight_and_fat_percentage():
     # 実装では tag/value は出力しない想定（存在しないことを確認）
     assert "tag" not in row
     assert "value" not in row
+
+
+def test_save_to_bigquery_skips_existing(monkeypatch):
+    raw_data = {
+        "data": [
+            {"date": "20250101000000", "keydata": "60", "tag": "6021"},
+            {"date": "20250102000000", "keydata": "61", "tag": "6021"},
+        ]
+    }
+
+    inserted = []
+
+    class DummyQueryJob:
+        def result(self):
+            return [SimpleNamespace(measured_at="2025-01-01T00:00:00")]
+
+    class DummyClient:
+        def query(self, *args, **kwargs):
+            return DummyQueryJob()
+
+        def insert_rows_json(self, table, rows):
+            inserted.extend(rows)
+            return []
+
+    dummy = DummyClient()
+    monkeypatch.setattr("app.services.healthplanet_service.bq_client", dummy)
+
+    result = save_to_bigquery("demo", raw_data)
+
+    assert result["ok"] is True
+    assert result["saved"] == 1
+    assert len(inserted) == 1
+    assert inserted[0]["measured_at"] == "2025-01-02T00:00:00"


### PR DESCRIPTION
## Summary
- dedupe HealthPlanet data in BigQuery by checking existing `measured_at`
- add regression test ensuring duplicate timestamps are skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1efe656088320957074bd5baa416d