### PR TITLE
Include meal memo in GPT prompt

### DIFF
--- a/app/external/openai_client.py
+++ b/app/external/openai_client.py
@@ -31,48 +31,53 @@ async def ask_gpt(text: str) -> str:
         data = r.json()
         return data["choices"][0]["message"]["content"]
 
-async def vision_extract_meal_bytes(data: bytes, mime: str | None) -> str:
-    """画像バイナリを base64 で直接 OpenAI に渡して食事内容を短く要約"""
+async def vision_extract_meal_bytes(
+    data: bytes, mime: str | None, memo: str | None = None
+) -> str:
+    """画像バイナリを base64 で直接 OpenAI に渡して食事内容を短く要約
+
+    メモがある場合はプロンプトに含める。"""
     if not settings.OPENAI_API_KEY:
         return "（OPENAI_API_KEY が未設定です）"
-    
+
     headers = {
-        "Authorization": f"Bearer {settings.OPENAI_API_KEY}", 
-        "Content-Type": "application/json"
+        "Authorization": f"Bearer {settings.OPENAI_API_KEY}",
+        "Content-Type": "application/json",
     }
     instruction = (
         "この食事写真を短い日本語テキストで説明してください。"
         "料理名・主な食材・推定量を簡潔に。可能なら大まかなカロリーも一言で。"
     )
-    
+
+    content = [
+        {"type": "text", "text": instruction}
+    ]
+
+    if memo:
+        content.append({"type": "text", "text": f"ユーザーのメモ: {memo}"})
+
     b64 = base64.b64encode(data).decode("utf-8")
-    
+    content.append(
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:{mime or 'image/jpeg'};base64,{b64}"},
+        }
+    )
+
     # Chat Completions API with Vision形式に修正
     body = {
         "model": "gpt-4o",  # Vision対応モデルを明示的に指定
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": instruction
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:{mime or 'image/jpeg'};base64,{b64}"
-                        }
-                    }
-                ]
-            }
-        ],
+        "messages": [{"role": "user", "content": content}],
         "max_tokens": 500,
-        "temperature": 0.3
+        "temperature": 0.3,
     }
-    
+
     async with httpx.AsyncClient(timeout=60.0) as client:
-        r = await client.post("https://api.openai.com/v1/chat/completions", headers=headers, json=body)
+        r = await client.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers=headers,
+            json=body,
+        )
         r.raise_for_status()
         j = r.json()
         return j["choices"][0]["message"]["content"]

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -31,6 +31,7 @@ async def ui_meal_image(
     x_api_token: str | None = Header(None, alias="x-api-token"),
     x_user_id: str | None = Header(None, alias="x-user-id"),
     when: str | None = Form(None),
+    memo: str | None = Form(None),
     file: UploadFile = File(...),
     dry: bool = Query(False),
 ):
@@ -74,7 +75,7 @@ async def ui_meal_image(
 
     try:
         logger.info(f"[MEAL_IMAGE] calling OpenAI, request_id={request_id}")
-        text = await vision_extract_meal_bytes(data, mime)
+        text = await vision_extract_meal_bytes(data, mime, memo)
         logger.info(f"[MEAL_IMAGE] OpenAI done, request_id={request_id}")
     except Exception as e:
         logger.exception(f"[MEAL_IMAGE] OpenAI error request_id={request_id}")
@@ -99,7 +100,7 @@ async def ui_meal_image(
         "mime": mime,
         "image_digest": image_digest,   # ←一本化（短縮版は使わない）
         "meal_kind": "other",
-        "notes": "",
+        "notes": memo or "",
         "user_id": user_id,             # ← payloadにも入れておく
     }
 

--- a/static/index.html
+++ b/static/index.html
@@ -1541,13 +1541,14 @@
                     const mealDate = document.getElementById('meal-date').value;
                     const mealTime = document.getElementById('meal-time').value;
                     const mealMemo = document.getElementById('meal-memo').value;
-                    
+
                     const whenISO = `${mealDate}T${mealTime}:00`;
 
                     // FormData for file upload
                     const formData = new FormData();
                     formData.append('file', this.selectedFile);
                     formData.append('when', whenISO);
+                    formData.append('memo', mealMemo);
 
                     // トークンがあればヘッダーに付与して1回だけ送信
                     const headers = this.apiToken ? { 'x-api-token': this.apiToken } : {};

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:8080")
+os.environ.setdefault("OPENAI_API_KEY", "test")
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -30,4 +31,38 @@ def test_meal_image_preview_empty_file_returns_400():
     )
     assert response.status_code == 400
     assert response.json()["error"] == "Empty file"
+
+
+def test_meal_image_includes_memo(monkeypatch):
+    """メモ付きでアップロードした場合、メモがGPTプロンプトと保存データに渡る"""
+    called = {}
+
+    async def fake_vision(data, mime, memo=None):
+        called["memo"] = memo
+        return "ok"
+
+    def fake_save(payload, user_id):
+        called["notes"] = payload.get("notes")
+        return {"ok": True, "dedup_key": "x", "firestore": {"skipped": False}}
+
+    monkeypatch.setattr(
+        "app.routers.ui.vision_extract_meal_bytes", fake_vision
+    )
+    monkeypatch.setattr(
+        "app.routers.ui.save_meal_to_stores", fake_save
+    )
+
+    import app.routers.ui as ui
+    monkeypatch.setattr(ui.settings, "OPENAI_API_KEY", "test", raising=False)
+
+    resp = client.post(
+        "/ui/meal_image",
+        data={"when": "2024-01-01T12:00:00", "memo": "ご飯大盛り"},
+        files={"file": ("img.png", b"123", "image/png")},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert called["memo"] == "ご飯大盛り"
+    assert called["notes"] == "ご飯大盛り"
 


### PR DESCRIPTION
## Summary
- pass optional memo text from meal upload UI to backend
- include memo in GPT vision prompt and save alongside meal data
- test that memo is forwarded to GPT and storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2fe7484bc8320b1a902c25680fb85