### PR TITLE
Include all meals in weekly coaching prompt

### DIFF
--- a/app/services/coaching_service.py
+++ b/app/services/coaching_service.py
@@ -37,7 +37,7 @@ def build_weekly_prompt(
         day_key = d["date"]
         meals = meals_by_day.get(day_key, [])
         meal_snippets = []
-        for m in meals[:2]:
+        for m in meals:
             kcal_val = m.get("kcal")
             kcal_part = f"（~{int(kcal_val)}kcal）" if isinstance(kcal_val, (int, float)) else ""
             text = (m.get("text") or "").strip()

--- a/tests/test_coaching_prompt.py
+++ b/tests/test_coaching_prompt.py
@@ -25,3 +25,25 @@ def test_build_weekly_prompt_includes_healthplanet_data():
 
     assert "体重60.0kg" in prompt
     assert "体脂肪率20.0%" in prompt
+
+def test_build_weekly_prompt_includes_all_meals():
+    days = [
+        {
+            "date": "2025-01-01",
+            "steps_total": "1000",
+            "sleep_line": "7h",
+            "spo2_line": "98",
+            "calories_total": "2000",
+        }
+    ]
+    meals_by_day = {
+        "2025-01-01": [
+            {"text": "Breakfast", "kcal": 300},
+            {"text": "Lunch", "kcal": 500},
+            {"text": "Dinner", "kcal": 700},
+        ]
+    }
+    prompt = build_weekly_prompt(days, meals_by_day)
+    assert "・Breakfast（~300kcal）" in prompt
+    assert "・Lunch（~500kcal）" in prompt
+    assert "・Dinner（~700kcal）" in prompt


### PR DESCRIPTION
## Summary
- show all meal entries in weekly coaching prompt
- test weekly prompt includes every meal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a308377d18832095910f49c7800f1e