### PR TITLE
Quote BigQuery reserved column and test meals query

### DIFF
--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -23,15 +23,15 @@ async def meals_last_n_days(n: int = 7, user_id: str = "demo") -> Dict[str, List
     table_id = f"{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}"
     query = f"""
         SELECT
-            when,
-            DATE(when) AS when_date,
+            `when`,
+            DATE(`when`) AS when_date,
             text,
             kcal,
             source
         FROM `{table_id}`
         WHERE user_id = @user_id
-          AND DATE(when) BETWEEN @start_date AND @end_date
-        ORDER BY when
+          AND DATE(`when`) BETWEEN @start_date AND @end_date
+        ORDER BY `when`
     """
     job_config = bigquery.QueryJobConfig(
         query_parameters=[
@@ -59,7 +59,7 @@ async def meals_last_n_days(n: int = 7, user_id: str = "demo") -> Dict[str, List
                 }
             )
     except Exception as e:
-        print(f"[ERROR] BigQuery meals fetch failed: {e}")
+        print(f"[ERROR] BigQuery meals fetch failed: {type(e).__name__}: {e}. query={query}")
 
     return result
 

--- a/tests/test_meal_service.py
+++ b/tests/test_meal_service.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+import asyncio
+from datetime import datetime, timezone, date
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.services import meal_service
+
+
+def test_meals_last_n_days_returns_meals(monkeypatch):
+    sample_row = SimpleNamespace(
+        when=datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc),
+        when_date=date(2024, 1, 2),
+        text="lunch",
+        kcal=600,
+        source="manual",
+    )
+
+    class DummyClient:
+        def query(self, query, job_config=None):
+            return [sample_row]
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(meal_service, "bq_client", dummy_client)
+    monkeypatch.setattr(meal_service.settings, "BQ_PROJECT_ID", "p")
+    monkeypatch.setattr(meal_service.settings, "BQ_DATASET", "d")
+    monkeypatch.setattr(meal_service.settings, "BQ_TABLE_MEALS", "t")
+
+    result = asyncio.run(meal_service.meals_last_n_days(1, "demo"))
+
+    assert result == {
+        "2024-01-02": [
+            {
+                "text": "lunch",
+                "kcal": 600,
+                "when": "2024-01-02T12:00:00+00:00",
+                "source": "manual",
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- quote `when` column in meal query and log query on failure
- add unit test for `meals_last_n_days`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32ad8bbf48320a7267822ba66bde4