### PR TITLE
Fix BigQuery meals ordering syntax

### DIFF
--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -86,7 +86,7 @@ async def get_meals_dashboard_data(
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
-        ORDER BY when_date ASC, when ASC
+        ORDER BY when_date ASC, `when` ASC
         """
         
         job_config = bigquery.QueryJobConfig(
@@ -336,7 +336,7 @@ async def get_dashboard_summary(
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
-        ORDER BY when_date ASC, when ASC
+        ORDER BY when_date ASC, `when` ASC
         """
 
         meals_config = bigquery.QueryJobConfig(query_parameters=[


### PR DESCRIPTION
## Summary
- escape BigQuery reserved `when` column in dashboard meal queries

## Testing
- `python -m py_compile app/routers/dashboard.py`
- `pytest -q` *(fails: KeyboardInterrupt from google.auth during startup)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bdc2f0088320b8a024d02a4d80bd