### PR TITLE
feat: add coach character selection

### DIFF
--- a/app/routers/coaching.py
+++ b/app/routers/coaching.py
@@ -8,6 +8,13 @@ import httpx
 
 router = APIRouter(tags=["coaching"])
 
+CHARACTER_PROMPTS = {
+    "A": "キャラクターAの口調で話してください。",
+    "B": "キャラクターBの口調で話してください。",
+    "C": "キャラクターCの口調で話してください。",
+    "D": "キャラクターDの口調で話してください。",
+}
+
 @router.get("/now")
 async def coach_now():
     """今すぐコーチング"""
@@ -37,10 +44,15 @@ async def coach_now_debug():
         return JSONResponse({"ok": False, "error": repr(e)}, status_code=500)
 
 @router.get("/weekly")
-async def coach_weekly(dry: bool = False, show_prompt: bool = False):
+async def coach_weekly(
+    dry: bool = False,
+    show_prompt: bool = False,
+    character: str | None = None,
+):
     """週次コーチング"""
     try:
-        result = await weekly_coaching(dry, show_prompt)
+        coach_prompt = CHARACTER_PROMPTS.get(character) if character else None
+        result = await weekly_coaching(dry, show_prompt, coach_prompt)
         return result
     except Exception as e:
         return JSONResponse({"ok": False, "where": "coach_weekly", "error": repr(e)}, status_code=500)

--- a/app/services/coaching_service.py
+++ b/app/services/coaching_service.py
@@ -29,6 +29,7 @@ def build_weekly_prompt(
     meals_by_day: Dict[str, List[Dict[str, Any]]],
     profile: Optional[Dict[str, Any]] = None,
     hp_by_day: Optional[Dict[str, Dict[str, Any]]] = None,
+    coach_prompt: Optional[str] = None,
 ) -> str:
     """コーチング用プロンプトを生成"""
     # 週次本文
@@ -106,6 +107,7 @@ def build_weekly_prompt(
         add("アレルギー", "allergies")
 
     profile_block = "\n".join(prof_lines) if prof_lines else "（プロフィール未設定）"
+    cp = f" {coach_prompt}" if coach_prompt else ""
 
     return f"""過去7日間のヘルスデータと食事記録です:
 {body}
@@ -113,7 +115,7 @@ def build_weekly_prompt(
 [プロフィール抜粋]
 {profile_block}
 
-あなたはヘルスケア&栄養のプロコーチです。
+あなたはヘルスケア&栄養のプロコーチです。{cp}
 すべての分析と提案は、ここまでに記載されたユーザーのプロフィール（年齢、性別、身長、体重、目標体重、運動目的、嗜好、既往歴、生活習慣、過去7日間のデータ）を必ず参照して行ってください。
 返答は以下の構成を必須とします。
 1.良かった点
@@ -171,7 +173,11 @@ async def daily_coaching() -> Dict[str, Any]:
         push_line(f"⚠️ cronエラー: {e}")
         return {"ok": False, "error": str(e)}
 
-async def weekly_coaching(dry: bool = False, show_prompt: bool = False) -> Dict[str, Any]:
+async def weekly_coaching(
+    dry: bool = False,
+    show_prompt: bool = False,
+    coach_prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """コーチングを実行"""
     try:
         # 循環インポートを避けるため、ここで import
@@ -205,7 +211,7 @@ async def weekly_coaching(dry: bool = False, show_prompt: bool = False) -> Dict[
         except Exception as e:
             print(f"[WARN] HealthPlanet fetch failed: {e}")
 
-        prompt    = build_weekly_prompt(days, meals_map, profile, hp_map)
+        prompt    = build_weekly_prompt(days, meals_map, profile, hp_map, coach_prompt)
         
         print("\n=== WEEKLY PROMPT ===\n", prompt, "\n=== END PROMPT ===\n")
         

--- a/static/index.html
+++ b/static/index.html
@@ -738,6 +738,31 @@
         #meals-table th {
             background-color: #f9f9f9;
         }
+
+        .coach-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+            justify-content: center;
+            margin-top: 20px;
+        }
+
+        .coach-option {
+            width: 120px;
+            height: 120px;
+            border: 2px dashed #ccc;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            border-radius: 10px;
+            background: #fff;
+        }
+
+        .coach-option.selected {
+            border-color: #ff6b35;
+            background: rgba(255,107,53,0.1);
+        }
     </style>
 </head>
 <body>
@@ -759,6 +784,7 @@
         <div class="nav-container">
             <div class="nav-tabs">
                 <button class="nav-tab active" data-page="profile">💪 ユーザー情報入力</button>
+                <button class="nav-tab" data-page="coach-setting">🎭 コーチキャラクター設定</button>
                 <button class="nav-tab" data-page="meal">🍚 食事画像アップロード</button>
                 <button class="nav-tab" data-page="coaching">🏋️ AIコーチング</button>
                 <button class="nav-tab" data-page="dashboard">📊 ダッシュボード</button>
@@ -854,6 +880,18 @@
                 </form>
 
                 <div id="profile-status"></div>
+            </div>
+            <!-- コーチキャラクター設定ページ -->
+            <div id="coach-setting" class="page">
+                <div class="section-title">
+                    🎭 コーチキャラクターを選択
+                </div>
+                <div class="coach-grid">
+                    <div class="coach-option" data-character="A">キャラクターA</div>
+                    <div class="coach-option" data-character="B">キャラクターB</div>
+                    <div class="coach-option" data-character="C">キャラクターC</div>
+                    <div class="coach-option" data-character="D">キャラクターD</div>
+                </div>
             </div>
 
             <!-- 食事画像アップロードページ -->
@@ -1031,6 +1069,7 @@
                 this.charts = {};
                 this.selectedFile = null;
                 this.isUploading = false;
+                this.selectedCoach = localStorage.getItem('fitai_coach') || 'A';
                 // PASTEされたデータに基づく既往歴オプション
                 this.pastHistoryOptions = [
                     {value: 'hypertension', label: '高血圧'},
@@ -1071,6 +1110,7 @@
                 document.getElementById('start-date').value = this.formatDate(sevenDaysAgo);
                 document.getElementById('end-date').value = this.formatDate(today);
                 this.setDefaultMealDateTime();
+                this.selectCoach(this.selectedCoach);
             }
 
             // イベントリスナー設定
@@ -1080,6 +1120,13 @@
                     tab.addEventListener('click', (e) => {
                         const page = e.currentTarget.dataset.page;
                         this.navigateToPage(page);
+                    });
+                });
+
+                // コーチキャラクター選択
+                document.querySelectorAll('.coach-option').forEach(opt => {
+                    opt.addEventListener('click', (e) => {
+                        this.selectCoach(e.currentTarget.dataset.character);
                     });
                 });
 
@@ -1621,6 +1668,15 @@
                 this.setDefaultMealDateTime();
             }
 
+            // コーチキャラクター選択
+            selectCoach(character) {
+                this.selectedCoach = character;
+                localStorage.setItem('fitai_coach', character);
+                document.querySelectorAll('.coach-option').forEach(opt => {
+                    opt.classList.toggle('selected', opt.dataset.character === character);
+                });
+            }
+
             // AIコーチング実行
             async runCoaching() {
                 const coachingBtn = document.getElementById('coaching-btn');
@@ -1630,8 +1686,11 @@
                 coachingBtn.innerHTML = '<span class="loading-spinner"></span> 実行中...';
 
                 try {
-                    const params = showPrompt ? '?show_prompt=1' : '';
-                    const response = await this.apiCall(`/coach/weekly${params}`);
+                    const params = new URLSearchParams();
+                    if (showPrompt) params.set('show_prompt', '1');
+                    if (this.selectedCoach) params.set('character', this.selectedCoach);
+                    const query = params.toString();
+                    const response = await this.apiCall(`/coach/weekly${query ? `?${query}` : ''}`);
 
                     if (response.ok) {
                         this.showStatus('coaching-status', '✅ コーチングを実行しました', 'success');

--- a/tests/test_coaching_prompt.py
+++ b/tests/test_coaching_prompt.py
@@ -47,3 +47,21 @@ def test_build_weekly_prompt_includes_all_meals():
     assert "・Breakfast（~300kcal）" in prompt
     assert "・Lunch（~500kcal）" in prompt
     assert "・Dinner（~700kcal）" in prompt
+
+
+def test_build_weekly_prompt_includes_coach_prompt():
+    days = [
+        {
+            "date": "2025-01-01",
+            "steps_total": "1000",
+            "sleep_line": "7h",
+            "spo2_line": "98",
+            "calories_total": "2000",
+        }
+    ]
+    meals_by_day = {"2025-01-01": []}
+    coach_prompt = "キャラクターAの口調で話してください。"
+
+    prompt = build_weekly_prompt(days, meals_by_day, coach_prompt=coach_prompt)
+
+    assert coach_prompt in prompt


### PR DESCRIPTION
## Summary
- add coach character setting page with 4 placeholders
- send selected coach style to weekly coaching API
- support custom coach prompts in weekly prompt builder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5de31d5288320a5023b91ffaf88b0