### PR TITLE
Show meal kcal and sort dashboard meals newest-first

### DIFF
--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -83,7 +83,7 @@ async def get_meals_dashboard_data(
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
-        ORDER BY when_date ASC, `when` ASC
+        ORDER BY when_date DESC, `when` DESC
         """
         
         job_config = bigquery.QueryJobConfig(
@@ -344,7 +344,7 @@ async def get_dashboard_summary(
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
-        ORDER BY when_date ASC, `when` ASC
+        ORDER BY when_date DESC, `when` DESC
         """
 
         meals_config = bigquery.QueryJobConfig(query_parameters=[

--- a/static/index.html
+++ b/static/index.html
@@ -2116,16 +2116,18 @@ try {
               tbody.innerHTML = '';
               theadRow.innerHTML = '';
 
-              const dates = Object.keys(mealsByDate || {}).sort();
-              let columns = [];
+              const dates = Object.keys(mealsByDate || {}).sort().reverse();
+              const columnsSet = new Set();
 
-              for (const date of dates) {
-                const meals = mealsByDate[date] || [];
-                if (meals.length > 0) {
-                  columns = Object.keys(meals[0]).filter(col => col !== 'source');
-                  break;
+              for (const meals of Object.values(mealsByDate || {})) {
+                for (const meal of meals) {
+                  Object.keys(meal).forEach(key => {
+                    if (key !== 'source') columnsSet.add(key);
+                  });
                 }
               }
+
+              const columns = Array.from(columnsSet).sort();
 
               theadRow.innerHTML = ['<th>日付</th>', ...columns.map(c => `<th>${c}</th>`)].join('');
 


### PR DESCRIPTION
## Summary
- Ensure the dashboard meal table always includes `kcal` values from `meals_updated`
- Display meal entries ordered by date descending on the dashboard
- Align BigQuery queries to fetch meals in descending date order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69094698c8320808a7221d6fe5179