### PR TITLE
Fix BigQuery meal query for dashboard calories

### DIFF
--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -77,8 +77,13 @@ async def get_meals_dashboard_data(
     
     try:
         # 食事データクエリ
+        # 画像は BigQuery に BLOB として保存されているため、
+        # フロントエンドで利用できるように Base64 へ変換して取得する
         meals_query = f"""
-        SELECT when_date, image_base64, kcal
+        SELECT
+            when_date,
+            TO_BASE64(image_blob) AS image_base64,
+            kcal
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
@@ -323,10 +328,11 @@ async def get_dashboard_summary(
         }
 
         # 食事データの取得
+        # 画像はBLOB形式で格納されているため、Base64文字列に変換して返す
         meals_query = f"""
         SELECT
             when_date,
-            image_base64,
+            TO_BASE64(image_blob) AS image_base64,
             kcal
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
         WHERE user_id = @user_id

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -27,7 +27,7 @@ async def meals_last_n_days(n: int = 7, user_id: str = "demo") -> Dict[str, List
             text,
             kcal,
             source,
-            image_base64
+            TO_BASE64(image_blob) AS image_base64
         FROM `{table_id}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date


### PR DESCRIPTION
## Summary
- Convert meal images stored as BigQuery BLOBs to Base64 when querying
- Ensure dashboard and meal service queries return kcal for each meal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b13ebbc883209cb78cb6cfb0f9a1