### PR TITLE
feat: ignore meal memo when saving

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -124,7 +124,6 @@ async def ui_meal_image(
         "image_digest": image_digest,   # ←一本化（短縮版は使わない）
         "image_base64": image_base64,
         "meal_kind": "other",
-        "notes": memo or "",
         "user_id": user_id,             # ← payloadにも入れておく
     }
 

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -34,7 +34,7 @@ def test_meal_image_preview_empty_file_returns_400():
 
 
 def test_meal_image_includes_memo(monkeypatch):
-    """メモ付きでアップロードした場合、メモがGPTプロンプトと保存データに渡る"""
+    """メモ付きでアップロードした場合、メモがGPTプロンプトに渡るが保存されない"""
     called = {}
 
     async def fake_vision(data, mime, memo=None):
@@ -64,7 +64,7 @@ def test_meal_image_includes_memo(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     assert called["memo"] == "ご飯大盛り"
-    assert called["notes"] == "ご飯大盛り"
+    assert called["notes"] is None
 
 
 def test_meal_image_saves_base64(monkeypatch):


### PR DESCRIPTION
## Summary
- ignore memo field when saving meal image uploads
- adjust tests to ensure memo is not persisted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71cfb343883209bdaf17b7a4a663f