### PR TITLE
feat: limit meal image upload size

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -59,6 +59,18 @@ async def ui_meal_image(
             status_code=400,
         )
 
+    max_size = 1024 * 1024  # 1MB
+    if len(data) > max_size:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": "File too large",
+                "message": "ファイルサイズを1MB未満にしてください",
+                "request_id": request_id,
+            },
+            status_code=400,
+        )
+
     if dry:
         return {
             "ok": True,
@@ -223,6 +235,17 @@ async def ui_meal_image_preview(
 
     if len(data) == 0:
         return JSONResponse({"ok": False, "error": "Empty file"}, status_code=400)
+
+    max_size = 1024 * 1024  # 1MB
+    if len(data) > max_size:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": "File too large",
+                "message": "ファイルサイズを1MB未満にしてください",
+            },
+            status_code=400,
+        )
 
     if not settings.OPENAI_API_KEY:
         return JSONResponse({"ok": False, "error": "OPENAI_API_KEY not set"}, status_code=500)

--- a/static/index.html
+++ b/static/index.html
@@ -1368,8 +1368,19 @@
                     return;
                 }
 
+                // ファイルサイズチェック（1MB = 1,048,576 バイト）
+                const maxSize = 1024 * 1024;
+                if (file.size > maxSize) {
+                    this.showStatus('meal-status', 'ファイルサイズを1MB未満にしてください', 'error');
+                    document.getElementById('file-input').value = '';
+                    document.getElementById('preview-container').style.display = 'none';
+                    document.getElementById('upload-btn').disabled = true;
+                    this.selectedFile = null;
+                    return;
+                }
+
                 this.selectedFile = file;
-                
+
                 // プレビュー表示
                 const reader = new FileReader();
                 reader.onload = (e) => {

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -24,6 +24,16 @@ def test_meal_image_empty_file_returns_400():
     assert response.json()["error"] == "Empty file"
 
 
+def test_meal_image_too_large_returns_400():
+    big_data = b"0" * (1024 * 1024 + 1)
+    response = client.post(
+        "/ui/meal_image?dry=true",
+        files={"file": ("big.png", big_data, "image/png")},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "File too large"
+
+
 def test_meal_image_preview_empty_file_returns_400():
     response = client.post(
         "/ui/meal_image/preview",
@@ -31,6 +41,16 @@ def test_meal_image_preview_empty_file_returns_400():
     )
     assert response.status_code == 400
     assert response.json()["error"] == "Empty file"
+
+
+def test_meal_image_preview_too_large_returns_400():
+    big_data = b"0" * (1024 * 1024 + 1)
+    response = client.post(
+        "/ui/meal_image/preview",
+        files={"file": ("big.png", big_data, "image/png")},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "File too large"
 
 
 def test_meal_image_includes_memo(monkeypatch):


### PR DESCRIPTION
## Summary
- warn and block meal image uploads over 1MB on the client
- validate image size server-side and return error for oversized files
- add tests for oversized meal image uploads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7215cc6e88320bb56b0d57ae1ad29