### PR TITLE
feat: allow separate meal table for dashboard

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,7 @@ class Settings:
     BQ_PROJECT_ID: str = os.getenv("BQ_PROJECT_ID", os.getenv("GOOGLE_CLOUD_PROJECT", ""))
     BQ_DATASET: str = os.getenv("BQ_DATASET", "health_raw")
     BQ_TABLE_MEALS: str = os.getenv("BQ_TABLE_MEALS", "meals_updated")
+    BQ_TABLE_MEALS_DASHBOARD: str = os.getenv("BQ_TABLE_MEALS_DASHBOARD", "meals")
     BQ_TABLE_FITBIT: str = os.getenv("BQ_TABLE_FITBIT", "fitbit_daily")
     BQ_TABLE_MONTHLY: str = os.getenv("BQ_TABLE_MONTHLY", "monthly_reports")
     BQ_TABLE_PROFILES: str = os.getenv("BQ_TABLE_PROFILES", "profiles")

--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -93,7 +93,7 @@ async def get_meals_dashboard_data(
             when_date,
             image_base64,
             kcal
-        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
+        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
         ORDER BY when_date DESC, `when` DESC
@@ -104,7 +104,7 @@ async def get_meals_dashboard_data(
             when_date,
             TO_BASE64(image_blob) AS image_base64,
             kcal
-        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
+        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
         ORDER BY when_date DESC, `when` DESC
@@ -311,7 +311,7 @@ async def get_dashboard_summary(
             when_date,
             image_base64,
             kcal
-        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
+        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
         ORDER BY when_date DESC, `when` DESC
@@ -321,7 +321,7 @@ async def get_dashboard_summary(
             when_date,
             TO_BASE64(image_blob) AS image_base64,
             kcal
-        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}`
+        FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
         ORDER BY when_date DESC, `when` DESC

--- a/tests/test_config_meal_tables.py
+++ b/tests/test_config_meal_tables.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app.config as config_module
+
+
+def test_meal_tables_configurable_independently(monkeypatch):
+    """Ensure dashboard and meal service tables can be set separately."""
+    monkeypatch.setenv("BQ_TABLE_MEALS", "meal_table")
+    monkeypatch.setenv("BQ_TABLE_MEALS_DASHBOARD", "dashboard_table")
+    importlib.reload(config_module)
+
+    assert config_module.settings.BQ_TABLE_MEALS == "meal_table"
+    assert config_module.settings.BQ_TABLE_MEALS_DASHBOARD == "dashboard_table"
+
+    # Clean up: reload settings without the overridden env vars
+    monkeypatch.delenv("BQ_TABLE_MEALS", raising=False)
+    monkeypatch.delenv("BQ_TABLE_MEALS_DASHBOARD", raising=False)
+    importlib.reload(config_module)


### PR DESCRIPTION
## Summary
- add `BQ_TABLE_MEALS_DASHBOARD` setting with default `meals`
- use dashboard-specific meal table in dashboard queries
- test configuration to ensure meal and dashboard tables are independently configurable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72625f1b48320b6eda16f0ca5b2b8