### PR TITLE
Remove image data from meals_last_n_days

### DIFF
--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -75,7 +75,6 @@ async def meals_last_n_days(n: int = 7, user_id: str = "demo") -> Dict[str, List
                     "kcal": row.kcal,
                     "when": row.when.isoformat() if getattr(row, "when", None) else None,
                     "source": row.source,
-                    "image_base64": getattr(row, "image_base64", None),
                 }
             )
     except Exception as e:

--- a/tests/test_meal_service.py
+++ b/tests/test_meal_service.py
@@ -46,7 +46,6 @@ def test_meals_last_n_days_returns_meals(monkeypatch):
                 "kcal": 600,
                 "when": "2024-01-02T12:00:00+00:00",
                 "source": "manual",
-                "image_base64": "abc",
             }
         ]
     }
@@ -86,4 +85,13 @@ def test_meals_last_n_days_falls_back_to_blob(monkeypatch):
     assert len(queries) == 2
     assert "image_base64" in queries[0]
     assert "TO_BASE64(image_blob)" in queries[1]
-    assert result["2024-01-02"][0]["image_base64"] == "abc"
+    assert result == {
+        "2024-01-02": [
+            {
+                "text": "lunch",
+                "kcal": 600,
+                "when": "2024-01-02T12:00:00+00:00",
+                "source": "manual",
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- Stop returning `image_base64` in `meals_last_n_days`
- Adjust meal service tests to match new result shape

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72c0cde408320a468fb06210e171e