### PR TITLE
Handle BigQuery schema mismatches more safely

### DIFF
--- a/tests/test_dashboard_fallback.py
+++ b/tests/test_dashboard_fallback.py
@@ -1,0 +1,61 @@
+import pytest
+from types import SimpleNamespace
+
+from app.routers import dashboard
+
+
+class DummyQueryJob:
+    def __init__(self, rows=None, error=None):
+        self.rows = rows or []
+        self.error = error
+
+    def result(self):
+        if self.error:
+            raise self.error
+        return self.rows
+
+
+def test_run_bq_with_fallback_schema_error(monkeypatch):
+    """Fallback should trigger when primary raises column related error."""
+
+    queries = []
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = 0
+
+        def query(self, sql, job_config=None):
+            queries.append(sql)
+            if self.calls == 0:
+                self.calls += 1
+                raise Exception("Unrecognized name: image_base64")
+            return DummyQueryJob(rows=[SimpleNamespace(dummy=1)])
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(dashboard, "bq_client", dummy_client)
+
+    rows = dashboard._run_bq_with_fallback("primary_sql", "fallback_sql", [])
+
+    assert len(rows) == 1
+    assert queries == ["primary_sql", "fallback_sql"]
+
+
+def test_run_bq_with_fallback_other_error(monkeypatch):
+    """Non schema errors should propagate without using fallback."""
+
+    queries = []
+
+    class DummyClient:
+        def query(self, sql, job_config=None):
+            queries.append(sql)
+            raise Exception("Some other error")
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(dashboard, "bq_client", dummy_client)
+
+    with pytest.raises(Exception) as exc:
+        dashboard._run_bq_with_fallback("primary_sql", "fallback_sql", [])
+
+    assert "Some other error" in str(exc.value)
+    assert queries == ["primary_sql"]
+


### PR DESCRIPTION
## Summary
- Only run BigQuery fallback queries on schema-related errors
- Add regression tests around dashboard query fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72ff25a98832086280a6d31d598e2