### PR TITLE
Exclude meal memo from stored text

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -112,6 +112,8 @@ async def ui_meal_image(
         logger.info(f"[MEAL_IMAGE] calling OpenAI, request_id={request_id}")
         text = await vision_extract_meal_bytes(data, mime, memo)
         logger.info(f"[MEAL_IMAGE] OpenAI done, request_id={request_id}")
+        if memo:
+            text = text.replace(f"ユーザーのメモ: {memo}", "").replace(memo, "").strip()
     except Exception as e:
         logger.exception(f"[MEAL_IMAGE] OpenAI error request_id={request_id}")
         return JSONResponse(

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -59,10 +59,11 @@ def test_meal_image_includes_memo(monkeypatch):
 
     async def fake_vision(data, mime, memo=None):
         called["memo"] = memo
-        return "ok"
+        return f"これは説明\nユーザーのメモ: {memo}"
 
     def fake_save(payload, user_id):
         called["notes"] = payload.get("notes")
+        called["text"] = payload.get("text")
         return {"ok": True, "dedup_key": "x", "firestore": {"skipped": False}}
 
     monkeypatch.setattr(
@@ -85,6 +86,7 @@ def test_meal_image_includes_memo(monkeypatch):
     assert resp.json()["ok"] is True
     assert called["memo"] == "ご飯大盛り"
     assert called["notes"] is None
+    assert "ご飯大盛り" not in called["text"]
 
 
 def test_meal_image_saves_base64(monkeypatch):


### PR DESCRIPTION
## Summary
- Strip user-provided memo from GPT result before saving meal data
- Test that memo is passed to GPT but omitted from stored text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab24ac9de883209a474bce1422d1fb