### PR TITLE
feat: support character-specific weekly coaching

### DIFF
--- a/app/database/firestore.py
+++ b/app/database/firestore.py
@@ -1,6 +1,6 @@
 from google.cloud import firestore
 from google.auth.exceptions import DefaultCredentialsError
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 try:
     db = firestore.Client()
@@ -31,3 +31,28 @@ def healthplanet_token_doc(user_id: str = "demo"):
     if not db:
         raise RuntimeError("Firestore client is not configured")
     return user_doc(user_id).collection("private").document("healthplanet_oauth")
+
+
+def _coach_settings_doc(user_id: str = "demo"):
+    """コーチ設定ドキュメントの参照を返す"""
+    if not db:
+        raise RuntimeError("Firestore client is not configured")
+    return user_doc(user_id).collection("private").document("settings")
+
+
+def get_coach_character(user_id: str = "demo") -> Optional[str]:
+    """選択中のコーチキャラクターを取得"""
+    if not db:
+        return None
+    snap = _coach_settings_doc(user_id).get()
+    if snap.exists:
+        data = snap.to_dict() or {}
+        return data.get("coach_character")
+    return None
+
+
+def set_coach_character(character: str, user_id: str = "demo") -> None:
+    """コーチキャラクターを保存"""
+    if not db:
+        return
+    _coach_settings_doc(user_id).set({"coach_character": character}, merge=True)

--- a/tests/test_weekly_coaching_character.py
+++ b/tests/test_weekly_coaching_character.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+import pytest
+import asyncio
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.services import coaching_service as cs
+
+
+def test_weekly_coaching_uses_saved_character(monkeypatch):
+    days = [{
+        "date": "2025-01-01",
+        "steps_total": "1000",
+        "sleep_line": "7h",
+        "spo2_line": "98",
+        "calories_total": "2000",
+    }]
+
+    async def dummy_fitbit_last_n_days(n):
+        return days
+
+    def dummy_save(user_id, d):
+        return d
+
+    monkeypatch.setattr("app.services.fitbit_service.fitbit_last_n_days", dummy_fitbit_last_n_days)
+    monkeypatch.setattr("app.services.fitbit_service.save_fitbit_daily_firestore", dummy_save)
+
+    async def dummy_meals_last_n_days(n, uid):
+        return {}
+    monkeypatch.setattr(cs, "meals_last_n_days", dummy_meals_last_n_days)
+    monkeypatch.setattr(cs, "get_latest_profile", lambda uid: {})
+    monkeypatch.setattr("app.database.bigquery.bq_upsert_fitbit_days", lambda uid, d: {})
+    monkeypatch.setattr("app.database.bigquery.bq_upsert_profile", lambda uid: {})
+    monkeypatch.setattr(cs, "ask_gpt", lambda prompt: "ok")
+    monkeypatch.setattr(cs, "push_line", lambda text: {"sent": True})
+    monkeypatch.setattr(cs, "get_coach_character", lambda user_id="demo": "D")
+
+    async def dummy_fetch_last7_data(uid):
+        return []
+    monkeypatch.setattr("app.services.healthplanet_service.fetch_last7_data", dummy_fetch_last7_data)
+    monkeypatch.setattr("app.services.healthplanet_service.parse_innerscan_for_prompt", lambda raw: [])
+
+    res = asyncio.run(cs.weekly_coaching(dry=True, show_prompt=True))
+    assert cs.CHARACTER_PROMPTS["D"] in res["prompt"]


### PR DESCRIPTION
## Summary
- persist selected coach character in Firestore
- generate weekly coaching with stored character prompt and send to LINE
- test weekly coaching uses saved character settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab29354b748320ad919db84640ed44