### PR TITLE
Add integration status API

### DIFF
--- a/app/routers/integration.py
+++ b/app/routers/integration.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+from app.database.firestore import fitbit_token_doc, healthplanet_token_doc
+
+router = APIRouter(prefix="/integration", tags=["integration"])
+
+
+@router.get("/status")
+def integration_status(user_id: str = "demo"):
+    """Return integration status for Fitbit and Health Planet."""
+    if user_id == "demo":
+        return {"fitbit": True, "healthplanet": True}
+
+    fitbit = False
+    healthplanet = False
+    try:
+        fitbit = fitbit_token_doc(user_id).get().exists
+    except Exception:
+        pass
+    try:
+        healthplanet = healthplanet_token_doc(user_id).get().exists
+    except Exception:
+        pass
+
+    return {"fitbit": fitbit, "healthplanet": healthplanet}

--- a/main.py
+++ b/main.py
@@ -12,8 +12,8 @@ import os
 
 # ルーターのインポート
 from app.routers import (
-    health, ui, fitbit, healthplanet, 
-    weight, meals, coaching, cron, debug, dashboard
+    health, ui, fitbit, healthplanet,
+    weight, meals, coaching, cron, debug, dashboard, integration
 )
 
 # ログ設定
@@ -100,6 +100,7 @@ app.include_router(meals.router, prefix="/meals")
 app.include_router(coaching.router, prefix="/coach")
 app.include_router(cron.router, prefix="/cron")
 app.include_router(debug.router, prefix="/debug")
+app.include_router(integration.router)
 app.include_router(dashboard.router)  # ダッシュボード追加
 
 @app.get("/api/health")


### PR DESCRIPTION
## Summary
- add `/integration/status` endpoint to report Fitbit and Health Planet integration status
- register new integration router in main application

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac03d8e7b48320b2d68fb00db4cf70