### PR TITLE
docs: explain RUN_BASE_URL Fitbit redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# FitAI v2
+
+## Setup
+
+### Fitbit OAuth Redirect URL
+
+Set the `RUN_BASE_URL` environment variable to the base URL where the application is served.
+The app derives the Fitbit OAuth 2.0 redirect URL by appending `/fitbit/auth` to this value.
+
+For example:
+
+```bash
+RUN_BASE_URL=https://example.com
+```
+
+which results in the redirect URI:
+
+```
+https://example.com/fitbit/auth
+```
+
+This exact URL — including protocol, domain, path, and port — must also be registered in the Fitbit Developer Portal. Any mismatch will cause Fitbit to return an `invalid_request` error.
+


### PR DESCRIPTION
## Summary
- document how RUN_BASE_URL forms the Fitbit OAuth redirect URL
- warn to register identical URL in the Fitbit Developer Portal to avoid `invalid_request`
- add example mapping RUN_BASE_URL to redirect URI

## Testing
- `pytest -q` *(fails: TypeError: 'bool' object is not subscriptable in test_integration_status_marks_services_linked)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1d0bd76c832096642b8145545cdf