### PR TITLE
Make Health Planet redirect URI configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# FitAI_v2
+
+## Configuration
+
+- `HP_REDIRECT_URI`: URL for the Health Planet OAuth callback. Set this to the application's `/healthplanet/auth`
+  endpoint and ensure it matches the URL registered in the Health Planet Developer Portal.
+

--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class Settings:
     HEALTHPLANET_CLIENT_ID: Optional[str] = os.getenv("HEALTHPLANET_CLIENT_ID")
     HEALTHPLANET_CLIENT_SECRET: Optional[str] = os.getenv("HEALTHPLANET_CLIENT_SECRET")
     HEALTHPLANET_SCOPE: str = os.getenv("HEALTHPLANET_SCOPE", "innerscan")
-    HP_REDIRECT_URI: str = "https://www.healthplanet.jp/success.html"
+    HP_REDIRECT_URI: str = os.getenv("HP_REDIRECT_URI", "https://www.healthplanet.jp/success.html")
     
     # LINE
     LINE_ACCESS_TOKEN: Optional[str] = os.getenv("LINE_ACCESS_TOKEN")

--- a/app/routers/integration.py
+++ b/app/routers/integration.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/integration", tags=["integration"])
 def integration_status(user_id: str = "demo"):
     """Return integration status for Fitbit and Health Planet."""
     if user_id == "demo":
-        return {"fitbit": True, "healthplanet": True}
+        return {"fitbit": {"linked": True}, "healthplanet": {"linked": True}}
 
     fitbit = False
     healthplanet = False
@@ -21,4 +21,4 @@ def integration_status(user_id: str = "demo"):
     except Exception:
         pass
 
-    return {"fitbit": fitbit, "healthplanet": healthplanet}
+    return {"fitbit": {"linked": fitbit}, "healthplanet": {"linked": healthplanet}}


### PR DESCRIPTION
## Summary
- make Health Planet redirect URI configurable via `HP_REDIRECT_URI` env variable
- document `HP_REDIRECT_URI` usage
- return `linked` status objects from `/integration/status`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac1e59bf948320a7b91e73b0b7f7f2