### PR TITLE
feat: redirect oauth callbacks to integration page

### DIFF
--- a/app/routers/fitbit.py
+++ b/app/routers/fitbit.py
@@ -52,7 +52,7 @@ async def auth_fitbit(code: str = "", state: str = ""):
         })
         
         push_line("✅ Fitbit連携が完了しました")
-        return RedirectResponse(url="/")
+        return RedirectResponse(url="/#integration")
     except httpx.HTTPStatusError as e:
         return JSONResponse({"ok": False, "where": "exchange", "status": e.response.status_code, "body": e.response.text}, status_code=500)
     except Exception as e:

--- a/app/routers/healthplanet.py
+++ b/app/routers/healthplanet.py
@@ -68,7 +68,7 @@ async def _exchange_and_store(code: str):
             "updated_at": jst_now().isoformat(),
         })
         
-        return RedirectResponse(url="/healthplanet/status")
+        return RedirectResponse(url="/#integration")
     
     except Exception as e:
         return JSONResponse({"ok": False, "error": str(e)}, status_code=500)


### PR DESCRIPTION
## Summary
- Redirect Fitbit OAuth callback to integration page
- Redirect Health Planet OAuth callback to integration page

## Testing
- `pytest -q` *(fails: KeyboardInterrupt - google.auth exponential backoff)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2a9eb7508320a3d4fb3d39b35a89