### PR TITLE
Compress large meal upload images automatically

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic>=2.5.0
 python-multipart>=0.0.6
 google-cloud-storage>=2.16.0
 aiofiles>=23.2.1  # 静的ファイル配信用（新規追加）
+Pillow>=10.0.0


### PR DESCRIPTION
## Summary
- Auto-compress meal images over 1MB before processing
- Support compression in preview endpoint and list Pillow dependency
- Add tests covering large image compression (skipped if Pillow unavailable)

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad3721dda083208a02c9c15b9996f8