### PR TITLE
feat: enable meal editing and deletion in dashboard

### DIFF
--- a/app/models/meal.py
+++ b/app/models/meal.py
@@ -13,3 +13,10 @@ class MealIn(BaseModel):
     def dict(self):
         """Pydantic v1互換のdict()メソッド"""
         return self.model_dump()
+
+
+class MealUpdate(BaseModel):
+    kcal: Optional[float] = None
+
+    def dict(self):
+        return self.model_dump()

--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -75,7 +75,8 @@ async def get_meals_dashboard_data(
         SELECT
             when_date,
             image_base64,
-            kcal
+            kcal,
+            dedup_key
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
@@ -99,6 +100,7 @@ async def get_meals_dashboard_data(
             meal_data = {
                 "image_base64": getattr(row, "image_base64", None),
                 "kcal": float(row.kcal) if row.kcal is not None else None,
+                "dedup_key": getattr(row, "dedup_key", None),
             }
 
             if date_str not in meals_by_date:
@@ -282,7 +284,8 @@ async def get_dashboard_summary(
         SELECT
             when_date,
             image_base64,
-            kcal
+            kcal,
+            dedup_key
         FROM `{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS_DASHBOARD}`
         WHERE user_id = @user_id
           AND when_date BETWEEN @start_date AND @end_date
@@ -297,6 +300,7 @@ async def get_dashboard_summary(
                 {
                     "image_base64": getattr(row, "image_base64", None),
                     "kcal": float(row.kcal) if row.kcal is not None else None,
+                    "dedup_key": getattr(row, "dedup_key", None),
                 }
             )
 

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -4,8 +4,13 @@ from fastapi import APIRouter, Header, File, UploadFile, Form, Query
 from fastapi.responses import JSONResponse
 from datetime import datetime, timezone
 from typing import Dict, Any
-from app.models.meal import MealIn
-from app.services.meal_service import save_meal_to_stores, validate_meal_data
+from app.models.meal import MealIn, MealUpdate
+from app.services.meal_service import (
+    save_meal_to_stores,
+    validate_meal_data,
+    update_meal_kcal,
+    delete_meal,
+)
 from app.external.openai_client import vision_extract_meal_bytes
 from app.config import settings
 from app.utils.auth_utils import require_token
@@ -124,6 +129,7 @@ async def ui_meal_image(
     try:
         if Image is not None:
             img = Image.open(BytesIO(data))
+            img = img.convert("RGB")
             img.thumbnail((512, 512))
             buf = BytesIO()
             img.save(buf, format="JPEG", quality=75)
@@ -250,6 +256,39 @@ def ui_meal(
     except Exception as e:
         logger.exception(f"[MEAL_TEXT] error request_id={request_id}")
         return JSONResponse({"ok": False, "error": str(e), "request_id": request_id}, status_code=500)
+
+
+@router.patch("/meal/{dedup_key}")
+def ui_update_meal(
+    dedup_key: str,
+    body: MealUpdate,
+    x_api_token: str | None = Header(None, alias="x-api-token"),
+    x_user_id: str | None = Header(None, alias="x-user-id"),
+):
+    require_token(x_api_token)
+    user_id = _resolve_user_id(x_user_id)
+    if body.kcal is None:
+        return JSONResponse({"ok": False, "error": "kcal is required"}, status_code=400)
+
+    result = update_meal_kcal(dedup_key, body.kcal, user_id)
+    if result["ok"]:
+        return {"ok": True, "dedup_key": dedup_key}
+    return JSONResponse({"ok": False, "error": "Failed to update meal", "details": result}, status_code=500)
+
+
+@router.delete("/meal/{dedup_key}")
+def ui_delete_meal(
+    dedup_key: str,
+    x_api_token: str | None = Header(None, alias="x-api-token"),
+    x_user_id: str | None = Header(None, alias="x-user-id"),
+):
+    require_token(x_api_token)
+    user_id = _resolve_user_id(x_user_id)
+
+    result = delete_meal(dedup_key, user_id)
+    if result["ok"]:
+        return {"ok": True, "dedup_key": dedup_key}
+    return JSONResponse({"ok": False, "error": "Failed to delete meal", "details": result}, status_code=500)
 
 # ⭐ プレビュー専用：保存なし
 @router.post("/meal_image/preview")

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -184,6 +184,82 @@ def save_meal_to_stores(meal_data: Dict[str, Any], user_id: str = "demo") -> Dic
         },
     }
 
+
+def update_meal_kcal(dedup_key: str, kcal: float, user_id: str = "demo") -> Dict[str, Any]:
+    from app.database.firestore import user_doc
+
+    try:
+        doc_ref = user_doc(user_id).collection("meals").document(dedup_key)
+        doc_ref.update({"kcal": kcal})
+        firestore_result = {"ok": True}
+    except Exception as e:
+        firestore_result = {"ok": False, "error": str(e)}
+
+    try:
+        if bq_client:
+            table_id = f"{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}"
+            query = f"""
+                UPDATE `{table_id}`
+                SET kcal = @kcal
+                WHERE user_id = @user_id AND dedup_key = @dedup_key
+            """
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[
+                    bigquery.ScalarQueryParameter("kcal", "FLOAT64", kcal),
+                    bigquery.ScalarQueryParameter("user_id", "STRING", user_id),
+                    bigquery.ScalarQueryParameter("dedup_key", "STRING", dedup_key),
+                ]
+            )
+            bq_client.query(query, job_config=job_config).result()
+            bq_result = {"ok": True}
+        else:
+            bq_result = {"ok": False, "reason": "bq disabled"}
+    except Exception as e:
+        bq_result = {"ok": False, "error": str(e)}
+
+    return {
+        "ok": firestore_result.get("ok") and bq_result.get("ok"),
+        "firestore": firestore_result,
+        "bigquery": bq_result,
+    }
+
+
+def delete_meal(dedup_key: str, user_id: str = "demo") -> Dict[str, Any]:
+    from app.database.firestore import user_doc
+
+    try:
+        doc_ref = user_doc(user_id).collection("meals").document(dedup_key)
+        doc_ref.delete()
+        firestore_result = {"ok": True}
+    except Exception as e:
+        firestore_result = {"ok": False, "error": str(e)}
+
+    try:
+        if bq_client:
+            table_id = f"{settings.BQ_PROJECT_ID}.{settings.BQ_DATASET}.{settings.BQ_TABLE_MEALS}"
+            query = f"""
+                DELETE FROM `{table_id}`
+                WHERE user_id = @user_id AND dedup_key = @dedup_key
+            """
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[
+                    bigquery.ScalarQueryParameter("user_id", "STRING", user_id),
+                    bigquery.ScalarQueryParameter("dedup_key", "STRING", dedup_key),
+                ]
+            )
+            bq_client.query(query, job_config=job_config).result()
+            bq_result = {"ok": True}
+        else:
+            bq_result = {"ok": False, "reason": "bq disabled"}
+    except Exception as e:
+        bq_result = {"ok": False, "error": str(e)}
+
+    return {
+        "ok": firestore_result.get("ok") and bq_result.get("ok"),
+        "firestore": firestore_result,
+        "bigquery": bq_result,
+    }
+
 def create_meal_dedup_key(meal_data: Dict[str, Any], user_id: str) -> str:
     """食事データの重複排除キーを生成"""
     import hashlib

--- a/static/index.html
+++ b/static/index.html
@@ -2203,13 +2203,13 @@ try {
               theadRow.innerHTML = '';
 
               const dates = Object.keys(mealsByDate || {}).sort().reverse();
-              theadRow.innerHTML = '<th>日付</th><th>画像</th><th>摂取カロリー</th>';
+              theadRow.innerHTML = '<th>日付</th><th>画像</th><th>摂取カロリー</th><th>操作</th>';
 
               for (const date of dates) {
                 const meals = mealsByDate[date] || [];
                 if (meals.length === 0) {
                   const tr = document.createElement('tr');
-                  tr.innerHTML = `<td>${date}</td><td colspan="2">--</td>`;
+                  tr.innerHTML = `<td>${date}</td><td colspan="3">--</td>`;
                   tbody.appendChild(tr);
                   continue;
                 }
@@ -2219,9 +2219,55 @@ try {
                     ? `<img src="data:image/jpeg;base64,${meal.image_base64}" style="max-width:100px;height:auto;" />`
                     : '';
                   const kcal = meal.kcal !== undefined && meal.kcal !== null ? meal.kcal : '';
-                  tr.innerHTML = `<td>${date}</td><td>${imgHtml}</td><td>${kcal}</td>`;
+                  const key = meal.dedup_key || '';
+                  tr.innerHTML = `<td>${date}</td><td>${imgHtml}</td>` +
+                    `<td><input type="number" value="${kcal}" data-dedup-key="${key}" style="width:80px;"></td>` +
+                    `<td><button class="update-meal-btn" data-dedup-key="${key}">保存</button> ` +
+                    `<button class="delete-meal-btn" data-dedup-key="${key}">削除</button></td>`;
                   tbody.appendChild(tr);
                 }
+              }
+
+              tbody.querySelectorAll('.update-meal-btn').forEach(btn => {
+                btn.addEventListener('click', async () => {
+                  const key = btn.dataset.dedupKey;
+                  const input = tbody.querySelector(`input[data-dedup-key="${key}"]`);
+                  const val = input ? input.value : '';
+                  await this.updateMealKcal(key, val);
+                });
+              });
+
+              tbody.querySelectorAll('.delete-meal-btn').forEach(btn => {
+                btn.addEventListener('click', async () => {
+                  const key = btn.dataset.dedupKey;
+                  if (!confirm('削除しますか？')) return;
+                  await this.deleteMeal(key);
+                });
+              });
+            }
+
+            async updateMealKcal(dedupKey, kcal) {
+              try {
+                await this.apiCall(`/ui/meal/${dedupKey}`, {
+                  method: 'PATCH',
+                  body: JSON.stringify({ kcal: parseFloat(kcal) })
+                });
+                this.showStatus('dashboard-status', 'カロリーを更新しました', 'success');
+                this.updateDashboard();
+              } catch (e) {
+                console.error(e);
+                this.showStatus('dashboard-status', '更新に失敗しました', 'error');
+              }
+            }
+
+            async deleteMeal(dedupKey) {
+              try {
+                await this.apiCall(`/ui/meal/${dedupKey}`, { method: 'DELETE' });
+                this.showStatus('dashboard-status', '削除しました', 'success');
+                this.updateDashboard();
+              } catch (e) {
+                console.error(e);
+                this.showStatus('dashboard-status', '削除に失敗しました', 'error');
               }
             }
 

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -20,8 +20,11 @@ def _create_large_image_bytes() -> bytes:
     pytest.importorskip("PIL")
     from PIL import Image
     import io
+    import os
 
-    img = Image.new("RGB", (3000, 3000), color="red")
+    size = (3000, 3000)
+    random_bytes = os.urandom(size[0] * size[1] * 3)
+    img = Image.frombytes("RGB", size, random_bytes)
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=95)
     data = buf.getvalue()


### PR DESCRIPTION
## Summary
- allow editing per-meal calories and deleting entries from the dashboard
- expose API endpoints and BigQuery/Firestore helpers for updating or removing meals
- return meal dedup keys with dashboard data and improve image compression handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4dfb6d9188320bb4f3731a25ab6b2