### PR TITLE
Add dedup_key to meals dashboard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FitAI v2
+
 ## Setup
+
 ### Health Planet OAuth Configuration
 - `HP_REDIRECT_URI`: URL for the Health Planet OAuth callback. Set this to the application's `/healthplanet/auth`
   endpoint and ensure it matches the URL registered in the Health Planet Developer Portal.
@@ -8,5 +10,11 @@
 Set the `RUN_BASE_URL` environment variable to the base URL where the application is served.
 The app derives the Fitbit OAuth 2.0 redirect URL by appending `/fitbit/auth` to this value.
 For example:
+
 ```bash
 RUN_BASE_URL=https://example.com
+```
+
+### BigQuery meals dashboard
+Set `BQ_TABLE_MEALS_DASHBOARD` to a BigQuery table or view that contains a `dedup_key` column.
+You can create or update the view using [`sql/meals_dashboard.sql`](sql/meals_dashboard.sql).

--- a/app/config.py
+++ b/app/config.py
@@ -6,7 +6,7 @@ class Settings:
     BQ_PROJECT_ID: str = os.getenv("BQ_PROJECT_ID", os.getenv("GOOGLE_CLOUD_PROJECT", ""))
     BQ_DATASET: str = os.getenv("BQ_DATASET", "health_raw")
     BQ_TABLE_MEALS: str = os.getenv("BQ_TABLE_MEALS", "meals_updated")
-    BQ_TABLE_MEALS_DASHBOARD: str = os.getenv("BQ_TABLE_MEALS_DASHBOARD", "meals")
+    BQ_TABLE_MEALS_DASHBOARD: str = os.getenv("BQ_TABLE_MEALS_DASHBOARD", "meals_dashboard")
     BQ_TABLE_FITBIT: str = os.getenv("BQ_TABLE_FITBIT", "fitbit_daily")
     BQ_TABLE_MONTHLY: str = os.getenv("BQ_TABLE_MONTHLY", "monthly_reports")
     BQ_TABLE_PROFILES: str = os.getenv("BQ_TABLE_PROFILES", "profiles")

--- a/sql/meals_dashboard.sql
+++ b/sql/meals_dashboard.sql
@@ -1,0 +1,14 @@
+-- Ensure the meals table includes a dedup_key column
+-- Replace `PROJECT_ID` and `DATASET` with actual values
+ALTER TABLE `PROJECT_ID.DATASET.meals`
+ADD COLUMN IF NOT EXISTS dedup_key STRING;
+
+-- View for dashboard queries that exposes dedup_key
+CREATE OR REPLACE VIEW `PROJECT_ID.DATASET.meals_dashboard` AS
+SELECT
+  user_id,
+  when_date,
+  image_base64,
+  kcal,
+  dedup_key
+FROM `PROJECT_ID.DATASET.meals`;


### PR DESCRIPTION
## Summary
- default dashboard table now `meals_dashboard`
- document BigQuery view with `dedup_key` column
- update README with `BQ_TABLE_MEALS_DASHBOARD` guidance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b53c677b148320a221b71e27183392