### PR TITLE
Avoid saving meal memos separately and fix image conversion

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -124,6 +124,7 @@ async def ui_meal_image(
     try:
         if Image is not None:
             img = Image.open(BytesIO(data))
+            img = img.convert("RGB")
             img.thumbnail((512, 512))
             buf = BytesIO()
             img.save(buf, format="JPEG", quality=75)

--- a/static/index.html
+++ b/static/index.html
@@ -1742,21 +1742,9 @@
                             document.getElementById('meal-status').appendChild(previewDiv);
                         }
 
-                        // メモがある場合は追加で送信
+                        // メモが入力されている場合は解析に利用したことのみ通知
                         if (mealMemo.trim()) {
-                            try {
-                                await this.apiCall('/ui/meal', {
-                                    method: 'POST',
-                                    body: JSON.stringify({
-                                        when: whenISO,
-                                        text: mealMemo,
-                                        kcal: null
-                                    })
-                                });
-                                this.showStatus('meal-status', '💬 メモも登録しました', 'success', true);
-                            } catch (error) {
-                                this.showStatus('meal-status', '⚠️ メモ保存に失敗（スキップ）', 'warning', true);
-                            }
+                            this.showStatus('meal-status', '💬 メモを解析に利用しました', 'info', true);
                         }
 
                         // フォームリセット

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -21,7 +21,8 @@ def _create_large_image_bytes() -> bytes:
     from PIL import Image
     import io
 
-    img = Image.new("RGB", (3000, 3000), color="red")
+    # 単色画像だとJPEG圧縮で1MB未満になることがあるためノイズ画像を生成
+    img = Image.effect_noise((3000, 3000), 100).convert("RGB")
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=95)
     data = buf.getvalue()


### PR DESCRIPTION
## Summary
- Stop UI from creating an extra meal entry for memo-only uploads
- Convert uploaded meal images to RGB before compression to ensure Base64 is always stored
- Generate noisy test images to reliably trigger compression logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a46bf5108320943ce8f39f6af0cb