### PR TITLE
Ensure Pillow dependency installation and warn if missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 # 依存関係ファイルをコピーしてインストール
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir Pillow && \
     pip install --no-cache-dir -r requirements.txt
 
 # アプリケーションコードをコピー

--- a/main.py
+++ b/main.py
@@ -29,6 +29,11 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+try:
+    from PIL import Image  # noqa: F401
+except ImportError:
+    logger.warning("Pillow is not installed. Install it with 'pip install Pillow' to enable image processing.")
+
 app = FastAPI(
     title="FitLine API",
     description="Fitness tracking and coaching application with multi-device support",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pydantic>=2.5.0
 python-multipart>=0.0.6
 google-cloud-storage>=2.16.0
 aiofiles>=23.2.1  # 静的ファイル配信用（新規追加）
-Pillow>=10.0.0
+Pillow>=10.0.0  # Image processing library


### PR DESCRIPTION
## Summary
- Add explicit Pillow dependency and installation instructions in Dockerfile
- Warn at startup if Pillow is missing to help diagnose missing image support

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81d75887c832081d997d9b53e012b