### PR TITLE
feat: raise meal image upload limit to 5MB

### DIFF
--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -79,7 +79,7 @@ async def ui_meal_image(
             status_code=400,
         )
 
-    max_size = 1024 * 1024  # 1MB
+    max_size = 5 * 1024 * 1024  # 5MB
     if len(data) > max_size:
         original_size = len(data)
         data, mime = _compress_image_to_limit(data, mime, max_size)
@@ -88,7 +88,7 @@ async def ui_meal_image(
                 {
                     "ok": False,
                     "error": "File too large",
-                    "message": "ファイルサイズを1MB未満にしてください",
+                    "message": "ファイルサイズを5MB未満にしてください",
                     "request_id": request_id,
                 },
                 status_code=400,
@@ -265,7 +265,7 @@ async def ui_meal_image_preview(
     if len(data) == 0:
         return JSONResponse({"ok": False, "error": "Empty file"}, status_code=400)
 
-    max_size = 1024 * 1024  # 1MB
+    max_size = 5 * 1024 * 1024  # 5MB
     if len(data) > max_size:
         original_size = len(data)
         data, mime = _compress_image_to_limit(data, mime, max_size)
@@ -274,7 +274,7 @@ async def ui_meal_image_preview(
                 {
                     "ok": False,
                     "error": "File too large",
-                    "message": "ファイルサイズを1MB未満にしてください",
+                    "message": "ファイルサイズを5MB未満にしてください",
                 },
                 status_code=400,
             )

--- a/static/index.html
+++ b/static/index.html
@@ -1392,10 +1392,10 @@
                     return;
                 }
 
-                // ファイルサイズチェック（1MB = 1,048,576 バイト）
-                const maxSize = 1024 * 1024;
+                // ファイルサイズチェック（5MB = 5,242,880 バイト）
+                const maxSize = 5 * 1024 * 1024;
                 if (file.size > maxSize) {
-                    this.showStatus('meal-status', 'ファイルサイズを1MB未満にしてください', 'error');
+                    this.showStatus('meal-status', 'ファイルサイズを5MB未満にしてください', 'error');
                     document.getElementById('file-input').value = '';
                     document.getElementById('preview-container').style.display = 'none';
                     document.getElementById('upload-btn').disabled = true;

--- a/tests/test_ui_meal_image.py
+++ b/tests/test_ui_meal_image.py
@@ -21,12 +21,12 @@ def _create_large_image_bytes() -> bytes:
     from PIL import Image
     import io
 
-    # 単色画像だとJPEG圧縮で1MB未満になることがあるためノイズ画像を生成
+    # 単色画像だとJPEG圧縮で5MB未満になることがあるためノイズ画像を生成
     img = Image.effect_noise((3000, 3000), 100).convert("RGB")
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=95)
     data = buf.getvalue()
-    assert len(data) > 1024 * 1024
+    assert len(data) > 5 * 1024 * 1024
     return data
 
 
@@ -46,7 +46,7 @@ def test_meal_image_large_image_is_compressed():
         files={"file": ("big.jpg", big_data, "image/jpeg")},
     )
     assert response.status_code == 200
-    assert response.json()["size"] <= 1024 * 1024
+    assert response.json()["size"] <= 5 * 1024 * 1024
 
 
 def test_meal_image_preview_empty_file_returns_400():
@@ -74,7 +74,7 @@ def test_meal_image_preview_large_image_is_compressed(monkeypatch):
         files={"file": ("big.jpg", big_data, "image/jpeg")},
     )
     assert response.status_code == 200
-    assert response.json()["size"] <= 1024 * 1024
+    assert response.json()["size"] <= 5 * 1024 * 1024
 
 
 def test_meal_image_includes_memo(monkeypatch):


### PR DESCRIPTION
## Summary
- raise maximum meal image size to 5MB for upload and preview
- update frontend size check and message to 5MB
- adjust tests for new 5MB limit

## Testing
- `pytest tests/test_ui_meal_image.py::test_meal_image_large_image_is_compressed tests/test_ui_meal_image.py::test_meal_image_preview_large_image_is_compressed -q`


------
https://chatgpt.com/codex/tasks/task_e_68b82f3e38688320bacec514f190e375