### PR TITLE
Update integration status to check Firestore for demo users

### DIFF
--- a/app/routers/integration.py
+++ b/app/routers/integration.py
@@ -4,21 +4,31 @@ from app.database.firestore import fitbit_token_doc, healthplanet_token_doc
 router = APIRouter(prefix="/integration", tags=["integration"])
 
 
+def _doc_exists(doc_ref) -> bool:
+    """Safely determine whether a Firestore document exists."""
+    try:
+        if doc_ref is None:
+            return False
+        snapshot = doc_ref.get()
+        return bool(getattr(snapshot, "exists", False))
+    except Exception:
+        return False
+
+
 @router.get("/status")
 def integration_status(user_id: str = "demo"):
     """Return integration status for Fitbit and Health Planet."""
-    if user_id == "demo":
-        return {"fitbit": {"linked": True}, "healthplanet": {"linked": True}}
+    try:
+        fitbit_doc = fitbit_token_doc(user_id)
+    except Exception:
+        fitbit_doc = None
 
-    fitbit = False
-    healthplanet = False
     try:
-        fitbit = fitbit_token_doc(user_id).get().exists
+        healthplanet_doc = healthplanet_token_doc(user_id)
     except Exception:
-        pass
-    try:
-        healthplanet = healthplanet_token_doc(user_id).get().exists
-    except Exception:
-        pass
+        healthplanet_doc = None
+
+    fitbit = _doc_exists(fitbit_doc)
+    healthplanet = _doc_exists(healthplanet_doc)
 
     return {"fitbit": {"linked": fitbit}, "healthplanet": {"linked": healthplanet}}

--- a/tests/test_integration_status.py
+++ b/tests/test_integration_status.py
@@ -7,6 +7,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from unittest.mock import MagicMock, patch
+
 from fastapi.testclient import TestClient
 from main import app
 
@@ -14,8 +16,32 @@ client = TestClient(app)
 
 
 def test_integration_status_marks_services_linked():
-    response = client.get("/integration/status?user_id=demo")
+    doc = MagicMock()
+    snapshot = MagicMock()
+    snapshot.exists = True
+    doc.get.return_value = snapshot
+
+    with patch("app.routers.integration.fitbit_token_doc", return_value=doc), \
+        patch("app.routers.integration.healthplanet_token_doc", return_value=doc):
+        response = client.get("/integration/status?user_id=demo")
+
     assert response.status_code == 200
     data = response.json()
     assert data["fitbit"]["linked"] is True
     assert data["healthplanet"]["linked"] is True
+
+
+def test_integration_status_marks_services_unlinked_when_missing():
+    doc = MagicMock()
+    snapshot = MagicMock()
+    snapshot.exists = False
+    doc.get.return_value = snapshot
+
+    with patch("app.routers.integration.fitbit_token_doc", return_value=doc), \
+        patch("app.routers.integration.healthplanet_token_doc", return_value=doc):
+        response = client.get("/integration/status?user_id=demo")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["fitbit"]["linked"] is False
+    assert data["healthplanet"]["linked"] is False


### PR DESCRIPTION
## Summary
- update the integration status endpoint to query Firestore for Fitbit and Health Planet tokens for all user IDs
- handle missing Firestore clients gracefully by treating tokens as unlinked
- expand tests to cover linked and unlinked token scenarios

## Testing
- pytest tests/test_integration_status.py


------
https://chatgpt.com/codex/tasks/task_e_68de6a6158408320b4173f7bf3ba0517